### PR TITLE
Make curl follow redirects when trying to retrieve latest CI image

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -210,7 +210,7 @@ export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
 #
 # if we provide OPENSHIFT_RELEASE_IMAGE, do not curl. This is needed for offline installs
 if [ -z "${OPENSHIFT_RELEASE_IMAGE:-}" ]; then
-  LATEST_CI_IMAGE=$(curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
+  LATEST_CI_IMAGE=$(curl -L https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"


### PR DESCRIPTION
Added -L flag to make curl follow redirects.
Currently I get redirects and dev-scripts is broken:

dev scripts error:
```
+++(common.sh:213): source(): curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.ci/latest
+++(common.sh:213): source(): grep -o 'registry.svc.ci.openshift.org[^"]\+'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   146  100   146    0     0     48      0  0:00:03  0:00:03 --:--:--    48
++(common.sh:213): source(): LATEST_CI_IMAGE=
```

manual curl output:
```
curl   https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.ci/latest  -i
HTTP/1.1 302 Moved Temporarily
Server: nginx/1.17.10
Date: Wed, 24 Jun 2020 07:29:41 GMT
Content-Type: text/html
Content-Length: 146
Location: http://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/api/v1/releasestream/4.6.0-0.ci/latest
Set-Cookie: 2280922aeb8a224efa194e9198e3546b=8bd70192fb507d72c0f75c167e80b907; path=/; HttpOnly; Secure

<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
<hr><center>nginx/1.17.10</center>
</body>
</html>
```

